### PR TITLE
Remove indices from plugins

### DIFF
--- a/database.py
+++ b/database.py
@@ -104,10 +104,12 @@ def add_manga(title):
     manga_dir = re.sub("^\-", "", manga_dir)
     manga_dir = re.sub("\-$", "", manga_dir)
 
+    sources = list(range(len(source.sources)))
+
     manga = Manga({
         "id": str(uuid.uuid4()),
         "title": title,
-        "sources": [0, 1],
+        "sources": sources,
         "dir": manga_dir,
         "cover": "cover.jpg",
         "downloaded_chapters": []})

--- a/plugins/mangalife.py
+++ b/plugins/mangalife.py
@@ -5,8 +5,6 @@ import requests
 from bs4 import BeautifulSoup
 import database
 
-i = 1
-
 class Source():
     def __init__(self):
         self.domain = "https://manga4life.com"

--- a/plugins/manganelo.py
+++ b/plugins/manganelo.py
@@ -5,8 +5,6 @@ import requests
 from bs4 import BeautifulSoup
 import database
 
-i = 2
-
 class Source():
     def __init__(self):
         self.domain = "https://manganelo.com"

--- a/source.py
+++ b/source.py
@@ -7,6 +7,7 @@ import queue
 import pathlib
 import database
 import uuid
+import importlib
 
 class ChapterDownloader(threading.Thread):
     def __init__(self):
@@ -135,13 +136,10 @@ class LocalSource():
     def __init__(self):
         self.name = "Local"
 
-import pathlib
-import importlib
-
 plugins_path = pathlib.Path("plugins")
 plugins_files = os.listdir(plugins_path)
-sources = {}
-sources[0] = LocalSource()
+sources = []
+sources.append(LocalSource())
 
 for file in plugins_files:
     if file.endswith(".py"):
@@ -150,5 +148,4 @@ for file in plugins_files:
         module.chapter_downloader = chapter_downloader
         module.image_downloader = image_downloader
         module.chapters_progress = chapters_progress
-        sources[module.i] = module.Source()
-sources = [sources[key] for key in sorted(sources.keys())]
+        sources.append(module.Source())


### PR DESCRIPTION
indices don't seem good as you'll have to keep track of them which becomes a hassle with more sources. Also, this makes every source available in right pane without having to edit source.